### PR TITLE
Use atomic_writes for address CSRs

### DIFF
--- a/litevideo/output/core.py
+++ b/litevideo/output/core.py
@@ -29,7 +29,7 @@ class Initiator(Module, AutoCSR):
 
         self.enable = CSRStorage()
         for name, width in frame_parameter_layout + frame_dma_layout:
-            setattr(self, name, CSRStorage(width, name=name))
+            setattr(self, name, CSRStorage(width, name=name, atomic_write=True))
             self.comb += getattr(cdc.sink, name).eq(getattr(self, name).storage)
         self.comb += cdc.sink.valid.eq(self.enable.storage)
         self.comb += cdc.source.connect(self.source)


### PR DESCRIPTION
@mithro asks: Why aren't we doing this?

Possibly addresses https://github.com/timvideos/HDMI2USB-litex-firmware/issues/346