### PR TITLE
Review: Regression Fix for 7-series HDMI Input and Output

### DIFF
--- a/litevideo/input/clocking.py
+++ b/litevideo/input/clocking.py
@@ -101,16 +101,16 @@ class S7Clocking(Module, AutoCSR):
 
         self.locked = Signal()
         self.clock_domains.cd_pix = ClockDomain()
+        self.clock_domains.cd_pix_o = ClockDomain()
         self.clock_domains.cd_pix1p25x = ClockDomain()
         self.clock_domains.cd_pix5x = ClockDomain(reset_less=True)
+        self.clock_domains.cd_pix5x_o = ClockDomain(reset_less=True)
 
         if split_clocking:
             self._mmcm_write_o = CSR()
             self._mmcm_read_o = CSR()
             self._mmcm_dat_o_r = CSRStatus(16)
             self._mmcm_drdy_o = CSRStatus()
-            self.clock_domains.cd_pix_o = ClockDomain()
-            self.clock_domains.cd_pix5x_o = ClockDomain(reset_less=True)
 
         # # #
 
@@ -218,6 +218,11 @@ class S7Clocking(Module, AutoCSR):
                     self._mmcm_drdy_o.status.eq(1)
                 )
             ]
+        else:
+            self.comb += [
+                self.cd_pix_o.clk.eq(self.cd_pix.clk),
+                self.cd_pix5x_o.clk.eq(self.cd_pix5x.clk)
+            ]
 
         self.specials += MultiReg(mmcm_locked, self.locked, "sys")
         self.comb += self._locked.status.eq(self.locked)
@@ -229,4 +234,6 @@ class S7Clocking(Module, AutoCSR):
 
         if split_clocking:
             self.specials += AsyncResetSynchronizer(self.cd_pix_o, ~mmcm_locked_o)
+        else:
+            self.comb += self.cd_pix_o.rst.eq(self.cd_pix.rst)
 

--- a/litevideo/output/driver.py
+++ b/litevideo/output/driver.py
@@ -60,4 +60,4 @@ class Driver(Module, AutoCSR):
             self.submodules.hdmi_phy = hdmi_phy_cls[family](pads, mode)
             if hasattr(self.hdmi_phy, "serdesstrobe"):
                 self.comb += self.hdmi_phy.serdesstrobe.eq(self.clocking.serdesstrobe)
-                self.comb += sink.connect(self.hdmi_phy.sink)
+            self.comb += sink.connect(self.hdmi_phy.sink)

--- a/litevideo/output/hdmi/s7.py
+++ b/litevideo/output/hdmi/s7.py
@@ -12,7 +12,7 @@ from litevideo.output.hdmi.encoder import Encoder
 class S7HDMIOutEncoderSerializer(Module):
     def __init__(self, pad_p, pad_n, bypass_encoder=False):
         if not bypass_encoder:
-            self.submodules.encoder = ClockDomainsRenamer("pix_o")(Encoder())
+            self.submodules.encoder = ClockDomainsRenamer("pix")(Encoder())
             self.d, self.c, self.de = self.encoder.d, self.encoder.c, self.encoder.de
             self.data = self.encoder.out
         else:
@@ -27,7 +27,7 @@ class S7HDMIOutEncoderSerializer(Module):
             self.comb += data.eq(self.data)
 
         ce = Signal()
-        self.sync.pix_o += ce.eq(~ResetSignal("pix_o"))
+        self.sync.pix += ce.eq(~ResetSignal("pix"))
 
         shift = Signal(2)
         pad_se = Signal()
@@ -42,8 +42,8 @@ class S7HDMIOutEncoderSerializer(Module):
                 o_OQ=pad_se,
                 i_OCE=ce,
                 i_TCE=0,
-                i_RST=ResetSignal("pix_o"),
-                i_CLK=ClockSignal("pix5x_o"), i_CLKDIV=ClockSignal("pix_o"),
+                i_RST=ResetSignal("pix"),
+                i_CLK=ClockSignal("pix5x"), i_CLKDIV=ClockSignal("pix"),
                 i_D1=data[0], i_D2=data[1],
                 i_D3=data[2], i_D4=data[3],
                 i_D5=data[4], i_D6=data[5],
@@ -59,8 +59,8 @@ class S7HDMIOutEncoderSerializer(Module):
 
                 i_OCE=ce,
                 i_TCE=0,
-                i_RST=ResetSignal("pix_o"),
-                i_CLK=ClockSignal("pix5x_o"), i_CLKDIV=ClockSignal("pix_o"),
+                i_RST=ResetSignal("pix"),
+                i_CLK=ClockSignal("pix5x"), i_CLKDIV=ClockSignal("pix"),
                 i_D1=0, i_D2=0,
                 i_D3=data[8], i_D4=data[9],
                 i_D5=0, i_D6=0,


### PR DESCRIPTION
Hi @enjoy-digital,

I'm not expecting the full PR to get merged since it might break any design using "pix_o" from HDMI input directly to drive the output HDMI (even if I think it is not a good idea). 

But at least, the commit 1e51823 can be merged without any major issues. It is a critical commit, without which the HDMI output will not work for 7-series devices.

The commit 411669b "re-reverts" the accidental revert which happened in commit 784cc8c. I've mentioned in commit message also.

The commit 17ebc03 requires some thorough review, and can possibly break some designs which directly use the clock from HDMI input to drive HDMI output. I've tried to explain the situation in the commit message. 

I've tested this PR with Mimas A7's `video` target in @timvideos/HDMI2USB-litex-firmware repo, and both HDMI output as well as HDMI input are now working with these changes. Issue #18 should also get resolved with this PR. Your review is high appreciated! 