### PR TITLE
terminal.core: Add read support via wishbone

### DIFF
--- a/litevideo/terminal/core.py
+++ b/litevideo/terminal/core.py
@@ -80,13 +80,17 @@ class Terminal(Module):
         self.specials += rdport
 
         # Memory map internal block RAM to Wishbone interface
-        self.sync += [
+        self.sync += [        
             wrport.we.eq(0),
-            If (bus.cyc & bus.stb & bus.we,
+            If (bus.cyc & bus.stb & bus.we & ~bus.ack,
                 wrport.we.eq(1),
-                wrport.adr.eq(bus.adr),
                 wrport.dat_w.eq(bus.dat_w),
-            )
+            ),
+        ]
+        
+        self.comb += [
+            wrport.adr.eq(bus.adr),
+            bus.dat_r.eq(wrport.dat_r)
         ]
 
         # Display resolution


### PR DESCRIPTION
In some cases it may be desirable if the VGA memory can be read back via the wishbone bus. 

This enables Read-Modify-Write operations, which can be useful to implement features like scrolling text.