### PR TITLE
input/clocking: use BUFG for ISERDESE2 CLK net

### DIFF
--- a/litevideo/input/clocking.py
+++ b/litevideo/input/clocking.py
@@ -165,7 +165,7 @@ class S7Clocking(Module, AutoCSR):
             ),
             Instance("BUFG", i_I=mmcm_clk0, o_O=self.cd_pix.clk),
             Instance("BUFG", i_I=mmcm_clk1, o_O=self.cd_pix1p25x.clk),
-            Instance("BUFIO",i_I=mmcm_clk2, o_O=self.cd_pix5x.clk),
+            Instance("BUFG", i_I=mmcm_clk2, o_O=self.cd_pix5x.clk),
             Instance("BUFG", i_I=mmcm_fb, o_O=mmcm_fb_o), # compensate this delay to minimize phase offset with slave
         ]
 


### PR DESCRIPTION
Without this change Vivado fails on routing `hdmi_in0_pix5x_clk` net in [my design](https://github.com/antmicro/netv2/blob/v4l2/netv2.py), it looks like that signal not only drives `ISERDESE2` but also a bit of logic resources.
```
Post Initial-Routing Verification
---------------------------------
CRITICAL WARNING: [Route 35-54] Net: hdmi_in0_pix5x_clk is not completely routed.
Resolution: Run report_route_status for more information.

Unroutable connection Types:
----------------------------
Type 1 : BUFIO.O->SLICEL.B6
-----Num Open nets: 1
-----Representative Net: Net[31] hdmi_in0_pix5x_clk
-----BUFIO_X0Y5.O -> SLICE_X0Y79.B6
-----Driver Term: BUFIO/O Load Term [4614]: ISERDESE2_35_i_1/I0
```
Additionally according to [SelectIO, p.153](https://www.xilinx.com/support/documentation/user_guides/ug471_7Series_SelectIO.pdf) `ISERDESE2` can be clocked by either a pair of `BUFG` or a `BUFIO` + `BUFR` so I'm not sure if the current arrangement is the optimal one, at least according to Xilinx.