### PR TITLE
input/edid: add support for I2C configuration used on NeTV2 board

### DIFF
--- a/litevideo/input/edid.py
+++ b/litevideo/input/edid.py
@@ -65,10 +65,22 @@ class EDID(Module, AutoCSR):
         else:
             self.specials += MultiReg(pads.scl, scl_raw)
 
-        self.specials += [
-            Tristate(pads.sda, 0, _sda_drv_reg, _sda_i_async),
-            MultiReg(_sda_i_async, sda_raw)
-        ]
+        if hasattr(pads, "sda_pu") and hasattr(pads, "sda_pd"):
+            pad_sda = getattr(pads, "sda")
+            if hasattr(pad_sda, "inverted"):
+                self.specials += MultiReg(~pads.sda, sda_raw)
+            else:
+                self.specials += MultiReg(pads.sda, sda_raw)
+
+            self.comb += [
+                pads.sda_pu.eq(0),
+                pads.sda_pd.eq(_sda_drv_reg),
+            ]
+        else:
+            self.specials += [
+                Tristate(pads.sda, 0, _sda_drv_reg, _sda_i_async),
+                MultiReg(_sda_i_async, sda_raw),
+            ]
 
         # for debug
         self.scl = scl_raw


### PR DESCRIPTION
This adds support for input-only `SDA` pin and a separate pair of pull-down/pull-up pins that control `SDA` line externally.
This requires enjoy-digital/litex#410 to work on NeTV2 board